### PR TITLE
Add build:html in build:all pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:css": "npm run scss && npm run autoprefix",
     "build:js": "npm run lint && npm run uglify",
     "build:images": "npm run imagemin && npm run icons",
-    "build:all": "npm run build:css && npm run build:js && npm run build:images",
+    "build:all": "npm run build:css && npm run build:js && npm run build:images && npm run build:html",
     "watch:html": "onchange \"src/templates/*.html\" -- npm run build:html",
     "watch:css": "onchange \"src/scss/*.scss\" -- npm run build:css",
     "watch:js": "onchange \"src/js/*.js\" -- npm run build:js",


### PR DESCRIPTION
Not sure if you skip it on purpose but processing the HTML should be a part of the build:all pipeline.