### PR TITLE
Add npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,17 @@ npm install
 ## Run
 
 ```bash
-npm run serve
+npm start
 ```
 
-## To watch for changes in Js, Css or Html
+## To watch for changes in JavaScript, CSS or HTML
 
 ```bash
 npm run watch:all
 ```
 
+## Build
+
+```bash
+npm run build:all
+```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "watch:html": "onchange \"src/templates/*.html\" -- npm run build:html",
     "watch:css": "onchange \"src/scss/*.scss\" -- npm run build:css",
     "watch:js": "onchange \"src/js/*.js\" -- npm run build:js",
-    "watch:all": "concurrently --kill-others \"npm run serve\" \"npm run watch:css\" \"npm run watch:js\" \"npm run watch:html\""
+    "watch:all": "concurrently --kill-others \"npm run serve\" \"npm run watch:css\" \"npm run watch:js\" \"npm run watch:html\"",
+    "start": "npm run serve"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.1",


### PR DESCRIPTION
This one basically adds a `npm start` shortcut to serve which I don't particularly like. What do you think? Should we point to serve or watch:all? I think that from the user perspective watch:all is the most used one.

Extra mile enhancing the docs just a little.