### PR TITLE
Add scaffold before start watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "watch:html": "nodemon --watch src/templates -e html -x \"npm run build:html\"",
     "watch:css": "nodemon --watch src/scss -e scss -x \"npm run build:css\"",
     "watch:js": "nodemon --watch src/js -e js -x \"npm run build:js\"",
-    "watch": "run-p serve watch:*",
+    "watch": "npm run build:scaffold && run-p serve watch:*",
     "start": "npm run watch"
   },
   "devDependencies": {


### PR DESCRIPTION
I've found an issue when you execute `npm start` because js folder is not generated. The thing is, `start` triggers `watch` which doesn't trigger `scaffold`.

In order to fix the issue I have added the `build:scaffold` before start watching. I think is working fine now. Of course this could be re-arranged in any other way, so I let you decide.